### PR TITLE
fix: Corregir el precio de la categoría 'Motherboard' en el component…

### DIFF
--- a/src/components/BannerOferta.jsx
+++ b/src/components/BannerOferta.jsx
@@ -24,7 +24,7 @@ const BannerOferta = () => {
     {
       id: 'componentes-motherboard',
       name: 'Motherboard',
-      price: '$999.990',
+      price: '$160.900',
       slug: 'componentes',
       imageKey: 'motherboard',
       tall: true // Ocupa 2 filas


### PR DESCRIPTION
…e BannerOferta

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected the displayed price for the Motherboard category on the promotional banner from $999,990 to $160,900.
  - Price now shows consistently across desktop, tablet, and mobile layouts.
  - No functional or interaction changes; only the displayed price was updated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->